### PR TITLE
Allow az config for targets

### DIFF
--- a/network-loadbalancer.cfndsl.rb
+++ b/network-loadbalancer.cfndsl.rb
@@ -52,7 +52,7 @@ CloudFormation do
       TargetType params['type'] if params.has_key?('type')
 
       if params.has_key?('type') and params['type'] == 'ip' and params.has_key? 'target_ips'
-        Targets (params['target_ips'].map {|ip|  { 'Id' => ip['ip'], 'Port' => ip['port'] }})
+        Targets (params['target_ips'].map {|ip|  { 'Id' => ip['ip'], 'Port' => ip['port'], 'AvailabilityZone' => ip['az']? ip['az'] : nil }.compact})
       end
 
       if params.has_key?('attributes')

--- a/tests/target_az.test.yaml
+++ b/tests/target_az.test.yaml
@@ -1,0 +1,34 @@
+test_metadata:
+  type: config
+  name: target_az
+  description: test specifying availability zone with a tcp listener and default target group
+
+loadbalancer_scheme: public
+static_ips: true
+
+loadbalancer_tags:
+  Name: aurora-proxy
+
+records:
+  - dbproxy
+
+targetgroups:
+  mysql:
+    protocol: tcp
+    port: 3306
+    type: ip
+    tags:
+      Name: MySQL-TCP
+    healthcheck:
+      HealthCheckPort: "traffic-port"
+      protocol: TCP
+    target_ips:
+      - ip: 10.1.2.16/32
+        port: 3306
+        az: all
+
+listeners:
+  mysql:
+    port: 3306
+    protocol: tcp
+    targetgroup: mysql


### PR DESCRIPTION
It is required that the AvailabilityZone config for a target IP that is external to the VPC is set to `all`.
AvailabilityZone can now be set explicitly for targets.