### PR TITLE
Feature/security group support

### DIFF
--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -3,24 +3,6 @@ name: cftest
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: test
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: set up ruby 2.7
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7.x
-    - name: install gems
-      run: gem install cfhighlander rspec 
-    - name: set cfndsl spec
-      run: cfndsl -u
-    - name: cftest
-      run: rspec
-      env:
-        AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: ap-southeast-2
-        
+  rspec:
+    uses: theonestack/shared-workflows/.github/workflows/rspec.yaml@main
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,43 @@
 # network-loadbalancer CfHighlander component
 
-![cftest](https://github.com/theonestack/hl-component-network-loadbalancer/actions/workflows/rspec.yaml/badge.svg)
+## Parameters
+
+| Name | Use | Default | Global | Type | Allowed Values |
+| ---- | --- | ------- | ------ | ---- | -------------- |
+| EnvironmentName | Tagging | dev | true | string
+| EnvironmentType | Tagging | development | true | string | ['development','production']
+| VPCId | Security Groups | None | false | AWS::EC2::VPC::Id
+| DnsDomain | DNS domain to use | None | true | string
+| SubnetIds | list of subnets | None | false | CommaDelimitedList
+| SecurityGroupIds | list of security group ids | None | false | CommaDelimitedList
+| SslCertId | ACM certificate ID | None | false | string (arn)
+| WebACLArn | ACL to use on the load balancer | None | false | string
+| HostedZoneId | Route53 Zone ID | None | false | string (arn)
+
+`HostedZoneId` is ONLY used if `use_zone_id` is True.
+
+
+## Outputs/Exports
+
+| Name | Value | Exported |
+| ---- | ----- | -------- |
+| {tg_name}TargetGroup | Target Group Name | true
+| {listener_name}Listener | Listener Name | true
+| LoadBalancer | Load Balancer ARN | true
+| LoadBalancerDNSName | Load Balancer URL | true
+| LoadBalancerCanonicalHostedZoneID | Load Balancer Hosted Zone ID | true
+
+## Example Configuration
+### Highlander
+```
+Component name: 'networkloadbalancer', template: 'networkloadbalancer'
+    parameter name: 'DnsDomain', value: root_domain
+    parameter name: 'SubnetIds', value: cfout('vpcv2', 'PublicSubnets')
+    parameter name: 'SecurityGroupIds', value: 'security_group1_id, security_group2_id'
+    parameter name: 'VPCId', value: cfout('vpcv2', 'VPCId')
+    parameter name: 'SslCertId', value: cfout('acmv2', 'CertificateArn')
+end
+```
 
 ## Cfhighlander Setup
 

--- a/network-loadbalancer.cfhighlander.rb
+++ b/network-loadbalancer.cfhighlander.rb
@@ -15,6 +15,7 @@ CfhighlanderTemplate do
     end
 
     ComponentParam 'SubnetIds', type: 'CommaDelimitedList'
+    ComponentParam 'SecurityGroupIds', type: 'CommaDelimitedList'
     ComponentParam 'VPCId', type: 'AWS::EC2::VPC::Id'
   end
 

--- a/network-loadbalancer.cfndsl.rb
+++ b/network-loadbalancer.cfndsl.rb
@@ -34,6 +34,9 @@ CloudFormation do
       Subnets Ref('SubnetIds')
     end
 
+    if !Ref('SecurityGroupIds').empty?
+      SecurityGroups Ref('SecurityGroupIds')
+
     Tags default_tags
     unless loadbalancer_attributes.nil?
       LoadBalancerAttributes loadbalancer_attributes.map {|key,value| { Key: key, Value: value } }

--- a/network-loadbalancer.cfndsl.rb
+++ b/network-loadbalancer.cfndsl.rb
@@ -18,6 +18,8 @@ CloudFormation do
   if !private && static_ips
     Condition(:StaticIPs, FnNot(FnEquals(Ref(:Nlb0EIPAllocationId), "")))
   end
+  
+  Condition(:AddSecurityGroups, FnNot(FnEquals(FnJoin(',', Ref(:SecurityGroupIds)), '')))
 
   ElasticLoadBalancingV2_LoadBalancer(:NetworkLoadBalancer) do
     Type 'network'
@@ -34,9 +36,10 @@ CloudFormation do
       Subnets Ref('SubnetIds')
     end
 
-    if !Ref('SecurityGroupIds').empty?
-      SecurityGroups Ref('SecurityGroupIds')
-
+    SecurityGroups(
+      FnIf(:AddSecurityGroups, Ref('SecurityGroupIds'), Ref('AWS::NoValue'))
+    )
+    
     Tags default_tags
     unless loadbalancer_attributes.nil?
       LoadBalancerAttributes loadbalancer_attributes.map {|key,value| { Key: key, Value: value } }


### PR DESCRIPTION
- Added support for security groups 

### Examples

**No security group supplied (Same as before)**
1. Deploy NLB without `SecurityGroupIds` supplied.
2. Observe NLB still deploys as expected with no security groups attached.
   <img width="846" alt="Screen Shot 2023-08-16 at 2 12 44 pm" src="https://github.com/theonestack/hl-component-network-loadbalancer/assets/64295670/359a118a-b970-491e-abc7-840d57ead086">
   <img width="329" alt="Screen Shot 2023-08-16 at 2 12 57 pm" src="https://github.com/theonestack/hl-component-network-loadbalancer/assets/64295670/a01088cc-9f19-4bb4-91ad-3afc415884b6">

**Security Group Ids Supplied**
1. Deploy NLB without `SecurityGroupIds` supplied.
```
Component name: 'networkloadbalancerwithsgs', template: 'git:https://github.com/theonestack/hl-component-network-loadbalancer#feature/security-group-support.snapshot' do
    parameter name: 'DnsDomain', value: 'bearsetest.ci.base2.services'
    parameter name: 'SubnetIds', value: cfout('vpc', 'PublicSubnets')
    parameter name: 'SecurityGroupIds', value: 'sg-02a2bb89cbe112998,sg-0135bdee08cceaf0f'
    parameter name: 'SslCertId', value: 'arn:aws:acm:ap-southeast-2:988966687271:certificate/934ce669-3beb-4ecb-a7bf-33780af881c5'
    parameter name: 'VPCId', value: cfout('vpc', 'VPCId')
  end
```
2. Observe NLB deploys as expected however now specified security groups are also attached as expected.
   <img width="440" alt="Screen Shot 2023-08-16 at 2 24 04 pm" src="https://github.com/theonestack/hl-component-network-loadbalancer/assets/64295670/7e0c1d97-3c02-4ffe-b2ce-91bd1736dbdd">
